### PR TITLE
Update github actions to specify ubuntu 24.04

### DIFF
--- a/.github/workflows/deploy-master-to-live.yml
+++ b/.github/workflows/deploy-master-to-live.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 jobs:
   deploy-live:
     name: Deploy master to live
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: deploy
 
     steps:

--- a/.github/workflows/deploy-preview-to-live.yml
+++ b/.github/workflows/deploy-preview-to-live.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 jobs:
   deploy-preview:
     name: Push preview to master and deploy to live
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: deploy
 
     steps:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 jobs:
   deploy-preview:
     name: Deploy preview branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: deploy
 
     steps:

--- a/.github/workflows/fetch-and-deploy-preview.yml
+++ b/.github/workflows/fetch-and-deploy-preview.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 jobs:
   deploy-preview:
     name: Fetch docs and deploy preview branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: deploy
 
     steps:


### PR DESCRIPTION
This PR updates the github actions to specify that it runs-on ubuntu-24.04. This stems from github actions issue [#10636](https://github.com/actions/runner-images/issues/10636). How to specify the runs-on version in .yml can be found [here](https://github.com/actions/runner-images/issues/9848). This will remove the warning message that appears when running an action to deploy the site.