### PR TITLE
Fix download draft instructions

### DIFF
--- a/docs/Draft-Generation/using-a-draft.md
+++ b/docs/Draft-Generation/using-a-draft.md
@@ -45,7 +45,7 @@ Once you've imported the draft to a project, sync the project in Scripture Forge
 
 ## Exporting USFM files
 
-If you prefer not to import the draft directly to your project, you can also download the draft as USFM files. On the "Generate draft" page, click "Download ZIP", and extract the files on your computer. You can then import these files into a project in Paratext.
+If you prefer not to import the draft directly to your project, you can also download the draft as USFM files. On the "Generate draft" page, click "Download draft", and extract the files on your computer. You can then import these files into a project in Paratext.
 
 ![](./download_usfm.png)
 


### PR DESCRIPTION
Previously it said to click "Download ZIP", but the actual button says "Download draft"